### PR TITLE
Fix: app did not deploy after exercise 11.21

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,6 +1,10 @@
 name: Deployment pipeline
 
 on:
+  push:
+    branches:
+      - main
+      
   pull_request:
     branches: [ main ]
     types: [ opened, synchronize ]


### PR DESCRIPTION
Add on-push to workflow. Main branch protection bypass temporarily enabled for this commit